### PR TITLE
Add ORBX export for TAG workflow

### DIFF
--- a/LMI_OctaneShotManager_Blender/registration.py
+++ b/LMI_OctaneShotManager_Blender/registration.py
@@ -9,6 +9,7 @@ from .tags_workflow import (
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,
+    LMB_OT_export_tags_orbx,
 )
 from .ui import POINTCLOUD_PT_panel
 
@@ -22,6 +23,7 @@ classes = (
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,
+    LMB_OT_export_tags_orbx,
     POINTCLOUD_PT_panel,
 )
 

--- a/LMI_OctaneShotManager_Blender/tags_workflow.py
+++ b/LMI_OctaneShotManager_Blender/tags_workflow.py
@@ -1,8 +1,16 @@
 import bpy
+import os
 from bpy.types import PropertyGroup, Operator, UIList
 from bpy.props import PointerProperty, BoolProperty
 
-from .utils import find_layer_collection
+from .utils import (
+    find_layer_collection,
+    ensure_directory,
+    generate_export_filename,
+    build_scene_shot_prefix,
+    ORBX_EXTENSION,
+    chunk_frame_range,
+)
 
 
 def _is_parent_of(parent, child):
@@ -140,11 +148,66 @@ class LMB_OT_tag_collection_remove(Operator):
         return {'FINISHED'}
 
 
+class LMB_OT_export_tags_orbx(Operator):
+    """Export all tagged collections to ORBX files."""
+    bl_idname = "lmb.export_tags_orbx"
+    bl_label = "Export All TAGs to ORBX"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        props = context.scene.otpc_props
+
+        def resolve_scene_name():
+            if props.scene_name_source == 'FILE':
+                filepath = bpy.data.filepath
+                return os.path.splitext(os.path.basename(filepath))[0] if filepath else ""
+            if props.scene_name_source == 'SCENE':
+                return context.scene.name
+            return props.scene_name_manual
+
+        def resolve_shot_name():
+            if props.shot_name_source == 'OBJECT':
+                obj = props.shot_object_source
+                return obj.name if obj else ""
+            return props.shot_name_manual
+
+        scene_name = resolve_scene_name()
+        shot_name = resolve_shot_name()
+
+        base_root = bpy.path.abspath(props.root_output_dir)
+        prefix = build_scene_shot_prefix(scene_name, shot_name)
+        base_dir = os.path.join(base_root, "Shot_Manager", "TAGs", prefix)
+        ensure_directory(base_dir)
+
+        frame_start = props.tag_frame_start
+        frame_end = props.tag_frame_end
+        ranges = [(frame_start, frame_end)]
+        if props.tag_use_chunks:
+            ranges = chunk_frame_range(frame_start, frame_end, max(1, props.tag_chunk_size))
+
+        for item in props.tag_collections:
+            coll = item.collection
+            if not coll:
+                continue
+            coll_name = coll.name
+            for r_start, r_end in ranges:
+                parts = [prefix, coll_name, f"{r_start}-{r_end}"]
+                filename = generate_export_filename(parts, ORBX_EXTENSION)
+                filepath = os.path.join(base_dir, filename)
+                bpy.ops.export.orbx(filepath=filepath,
+                                    frame_start=r_start,
+                                    frame_end=r_end)
+
+        self.report({'INFO'}, "ORBX TAG export completed.")
+        return {'FINISHED'}
+
+
 classes = (
     TagCollectionItem,
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,
+    LMB_OT_export_tags_orbx,
 )
 
 

--- a/LMI_OctaneShotManager_Blender/ui.py
+++ b/LMI_OctaneShotManager_Blender/ui.py
@@ -74,6 +74,7 @@ class POINTCLOUD_PT_panel(Panel):
             row.prop(p, 'tag_use_chunks')
             if p.tag_use_chunks:
                 row.prop(p, 'tag_chunk_size', text='Chunk')
+            tag_box.operator('lmb.export_tags_orbx', text="Export All Tags to ORBX", icon='EXPORT')
             layout.separator()
             
         # PointCloud Baker dropdown

--- a/LMI_OctaneShotManager_Blender/utils.py
+++ b/LMI_OctaneShotManager_Blender/utils.py
@@ -10,6 +10,7 @@ import csv
 # -----------------------------------------------------------------------------
 CSV_EXTENSION = 'csv'
 ABC_EXTENSION = 'abc'
+ORBX_EXTENSION = 'orbx'
 
 # -----------------------------------------------------------------------------
 # Directory Helpers
@@ -190,4 +191,15 @@ def parse_frame_range(frame_range_str):
             except ValueError:
                 continue
     return sorted(frames)
+
+
+def chunk_frame_range(start, end, chunk_size):
+    """Return list of (start, end) tuples split into chunk_size increments."""
+    ranges = []
+    cur = start
+    while cur <= end:
+        chunk_end = min(cur + chunk_size - 1, end)
+        ranges.append((cur, chunk_end))
+        cur = chunk_end + 1
+    return ranges
 


### PR DESCRIPTION
## Summary
- add ORBX file extension constant and helper to chunk frame ranges
- implement operator to export tagged collections as ORBX files
- register new operator and expose button in UI

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68765aee71fc8320b3883b02ef9d4c3f