### PR TITLE
Add ORBX export for TAG workflow

### DIFF
--- a/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
@@ -1,0 +1,129 @@
+import os
+import bpy
+from bpy.types import Operator
+
+from ..properties import OctanePointCloudProperties
+from ..utils import (
+    ensure_directory,
+    build_scene_shot_prefix,
+    find_layer_collection,
+    generate_export_filename,
+    chunk_frame_ranges,
+    ORBX_EXTENSION,
+)
+
+
+class LMB_OT_export_orbx_tags(Operator):
+    """Export each tagged collection as ORBX files."""
+    bl_idname = "lmb.export_orbx_tags"
+    bl_label = "Export All TAGs to ORBX"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        props = context.scene.otpc_props  # type: OctanePointCloudProperties
+
+        def resolve_scene_name():
+            if props.scene_name_source == 'FILE':
+                filepath = bpy.data.filepath
+                return os.path.splitext(os.path.basename(filepath))[0] if filepath else ""
+            if props.scene_name_source == 'SCENE':
+                return context.scene.name
+            return props.scene_name_manual
+
+        def resolve_shot_name():
+            if props.shot_name_source == 'OBJECT':
+                obj = props.shot_object_source
+                return obj.name if obj else ""
+            return props.shot_name_manual
+
+        scene_name = resolve_scene_name()
+        shot_name = resolve_shot_name()
+
+        base_root = bpy.path.abspath(props.root_output_dir)
+        prefix = build_scene_shot_prefix(scene_name, shot_name)
+        base_dir = os.path.join(base_root, "Shot_Manager", "TAGs", prefix)
+        ensure_directory(base_dir)
+
+        frame_start = props.tags_frame_start
+        frame_end = props.tags_frame_end
+        ranges = list(chunk_frame_ranges(frame_start, frame_end, props.tags_chunk_size if props.tags_use_chunking else (frame_end - frame_start + 1)))
+
+        bpy.context.scene.render.engine = 'octane'
+
+        root_layer = context.view_layer.layer_collection
+
+        def walk_layers(layer, lst):
+            lst.append(layer)
+            for ch in layer.children:
+                walk_layers(ch, lst)
+
+        all_layers = []
+        walk_layers(root_layer, all_layers)
+        original_states = {lc: lc.exclude for lc in all_layers}
+
+        def set_all(state):
+            for lc in all_layers:
+                lc.exclude = state
+
+        def unhide_path(layer_coll):
+            if layer_coll is None:
+                return
+            layer_coll.exclude = False
+            parent = getattr(layer_coll, "parent", None)
+            if parent:
+                unhide_path(parent)
+
+        def unhide_children(layer_coll):
+            layer_coll.exclude = False
+            for ch in layer_coll.children:
+                unhide_children(ch)
+
+        exported = 0
+        for item in props.tag_collections:
+            coll = item.collection
+            if not coll:
+                continue
+            target_layer = find_layer_collection(root_layer, coll)
+            if not target_layer:
+                continue
+
+            set_all(True)
+            unhide_path(target_layer)
+            unhide_children(target_layer)
+
+            base_name = f"{prefix}_{coll.name}"
+            for start, end in ranges:
+                filename = generate_export_filename([base_name, f"{start}-{end}"], ORBX_EXTENSION)
+                filepath = os.path.join(base_dir, filename)
+                bpy.ops.export.orbx(
+                    'EXEC_DEFAULT',
+                    filepath=filepath,
+                    check_existing=True,
+                    filename=os.path.basename(filepath),
+                    frame_start=start,
+                    frame_end=end,
+                    frame_subframe=0.0,
+                    filter_glob="*.orbx"
+                )
+                exported += 1
+
+        for lc, val in original_states.items():
+            lc.exclude = val
+
+        self.report({'INFO'}, f"Exported {exported} ORBX files.")
+        return {'FINISHED'}
+
+
+classes = (
+    LMB_OT_export_orbx_tags,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/LMI_OctaneShotManager_Blender/properties.py
+++ b/LMI_OctaneShotManager_Blender/properties.py
@@ -148,3 +148,28 @@ class OctanePointCloudProperties(bpy.types.PropertyGroup):
 
     tag_collections: CollectionProperty(type=TagCollectionItem)
     tag_collections_index: IntProperty(default=-1)
+
+    tags_frame_start: IntProperty(
+        name="Start Frame",
+        description="First frame for TAGs export",
+        default=1,
+    )
+
+    tags_frame_end: IntProperty(
+        name="End Frame",
+        description="Last frame for TAGs export",
+        default=250,
+    )
+
+    tags_use_chunking: BoolProperty(
+        name="Use Chunking",
+        description="Split export frame range into sequential chunks",
+        default=False,
+    )
+
+    tags_chunk_size: IntProperty(
+        name="Chunk Size",
+        description="Number of frames per chunk",
+        default=25,
+        min=1,
+    )

--- a/LMI_OctaneShotManager_Blender/registration.py
+++ b/LMI_OctaneShotManager_Blender/registration.py
@@ -4,6 +4,7 @@ from .icons import load_icons, unload_icons
 from .properties import OctanePointCloudProperties
 from .exporters.csv_export import LMB_OT_export_csv
 from .exporters.abc_export import LMB_OT_export_abc
+from .exporters.orbx_export import LMB_OT_export_orbx_tags
 from .tags_workflow import (
     TagCollectionItem,
     LMB_UL_tag_collections,
@@ -19,6 +20,7 @@ classes = (
     OctanePointCloudProperties,
     LMB_OT_export_csv,
     LMB_OT_export_abc,
+    LMB_OT_export_orbx_tags,
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,

--- a/LMI_OctaneShotManager_Blender/ui.py
+++ b/LMI_OctaneShotManager_Blender/ui.py
@@ -64,6 +64,12 @@ class POINTCLOUD_PT_panel(Panel):
             col = row.column(align=True)
             col.operator('lmb.tag_collection_add', icon='ADD', text='')
             col.operator('lmb.tag_collection_remove', icon='REMOVE', text='')
+            tag_box.prop(p, 'tags_frame_start')
+            tag_box.prop(p, 'tags_frame_end')
+            tag_box.prop(p, 'tags_use_chunking')
+            if p.tags_use_chunking:
+                tag_box.prop(p, 'tags_chunk_size')
+            tag_box.operator('lmb.export_orbx_tags', icon='EXPORT')
             layout.separator()
             
         # PointCloud Baker dropdown

--- a/LMI_OctaneShotManager_Blender/utils.py
+++ b/LMI_OctaneShotManager_Blender/utils.py
@@ -10,6 +10,7 @@ import csv
 # -----------------------------------------------------------------------------
 CSV_EXTENSION = 'csv'
 ABC_EXTENSION = 'abc'
+ORBX_EXTENSION = 'orbx'
 
 # -----------------------------------------------------------------------------
 # Directory Helpers
@@ -190,4 +191,16 @@ def parse_frame_range(frame_range_str):
             except ValueError:
                 continue
     return sorted(frames)
+
+
+def chunk_frame_ranges(start, end, size):
+    """Yield (start, end) tuples split into chunks."""
+    if size <= 0:
+        yield (start, end)
+        return
+    current = start
+    while current <= end:
+        chunk_end = min(current + size - 1, end)
+        yield (current, chunk_end)
+        current += size
 


### PR DESCRIPTION
## Summary
- add ORBX extension constant and frame chunk helper
- add TAG workflow export settings
- implement ORBX export operator for tagged collections
- hook up operator in registration and UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876ddc7bd3c8320bd48bd7c3e786742