### PR TITLE
Fix ORBX export sequencing

### DIFF
--- a/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
@@ -6,9 +6,11 @@ from ..properties import OctanePointCloudProperties
 from ..utils import (
     ensure_directory,
     build_scene_shot_prefix,
-    find_layer_collection,
     generate_export_filename,
     chunk_frame_ranges,
+    wait_for_export,
+    iterate_collections,
+    build_parent_map,
     ORBX_EXTENSION,
 )
 
@@ -51,32 +53,23 @@ class LMB_OT_export_orbx_tags(Operator):
 
         bpy.context.scene.render.engine = 'octane'
 
-        root_layer = context.view_layer.layer_collection
-
-        def walk_layers(layer, lst):
-            lst.append(layer)
-            for ch in layer.children:
-                walk_layers(ch, lst)
-
-        all_layers = []
-        walk_layers(root_layer, all_layers)
-        original_states = {lc: lc.exclude for lc in all_layers}
+        root_collection = context.scene.collection
+        all_collections = list(iterate_collections(root_collection))
+        parent_map = build_parent_map(root_collection)
+        original_states = {c: c.hide_render for c in all_collections}
 
         def set_all(state):
-            for lc in all_layers:
-                lc.exclude = state
+            for c in all_collections:
+                c.hide_render = state
 
-        def unhide_path(layer_coll):
-            if layer_coll is None:
-                return
-            layer_coll.exclude = False
-            parent = getattr(layer_coll, "parent", None)
-            if parent:
-                unhide_path(parent)
+        def unhide_path(coll):
+            while coll:
+                coll.hide_render = False
+                coll = parent_map.get(coll)
 
-        def unhide_children(layer_coll):
-            layer_coll.exclude = False
-            for ch in layer_coll.children:
+        def unhide_children(coll):
+            coll.hide_render = False
+            for ch in coll.children:
                 unhide_children(ch)
 
         exported = 0
@@ -84,13 +77,10 @@ class LMB_OT_export_orbx_tags(Operator):
             coll = item.collection
             if not coll:
                 continue
-            target_layer = find_layer_collection(root_layer, coll)
-            if not target_layer:
-                continue
 
             set_all(True)
-            unhide_path(target_layer)
-            unhide_children(target_layer)
+            unhide_path(coll)
+            unhide_children(coll)
 
             base_name = f"{prefix}_{coll.name}"
             for start, end in ranges:
@@ -107,12 +97,14 @@ class LMB_OT_export_orbx_tags(Operator):
                     "frame_subframe=0.0, filter_glob='*.orbx')"
                 )
 
+                print(f"Executing: {command}")
                 result = eval(command)
-                print(f"Executed: {command}\nORBX export finished: {result} → {filepath}")
+                wait_for_export(filepath)
+                print(f"ORBX export finished: {result} → {filepath}")
                 exported += 1
 
-        for lc, val in original_states.items():
-            lc.exclude = val
+        for col, val in original_states.items():
+            col.hide_render = val
 
         self.report({'INFO'}, f"Exported {exported} ORBX files.")
         return {'FINISHED'}

--- a/LMI_OctaneShotManager_Blender/utils.py
+++ b/LMI_OctaneShotManager_Blender/utils.py
@@ -204,3 +204,37 @@ def chunk_frame_ranges(start, end, size):
         yield (current, chunk_end)
         current += size
 
+
+def wait_for_export(filepath, timeout=300, poll=0.5):
+    """Wait until the ORBX export finishes writing the file."""
+    start_time = time.perf_counter()
+    last_size = -1
+    while time.perf_counter() - start_time < timeout:
+        if os.path.exists(filepath):
+            current_size = os.path.getsize(filepath)
+            if current_size > 0 and current_size == last_size:
+                return True
+            last_size = current_size
+        time.sleep(poll)
+    return False
+
+
+def iterate_collections(root):
+    """Yield collections recursively starting from ``root``."""
+    yield root
+    for child in root.children:
+        yield from iterate_collections(child)
+
+
+def build_parent_map(root):
+    """Return a mapping of child collection -> parent collection."""
+    parent_map = {}
+
+    def _walk(coll):
+        for ch in coll.children:
+            parent_map[ch] = coll
+            _walk(ch)
+
+    _walk(root)
+    return parent_map
+


### PR DESCRIPTION
## Summary
- hide all non-exported collections when writing ORBX files
- wait for each file to finish writing before continuing
- helpers for collection traversal and waiting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876fc058014832095413ca850724aa7