### PR TITLE
Add ORBX export workflow

### DIFF
--- a/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
+++ b/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
@@ -1,4 +1,5 @@
 import bpy
+import os
 from ...utils import find_layer_collection
 
 
@@ -43,3 +44,78 @@ def cycle_tag_collections(context):
 
     solo_collection(context, coll)
     return coll
+
+
+def chunk_frame_ranges(start, end, step):
+    """Split [start..end] into sequential chunks of size 'step'."""
+    chunks = []
+    cur = start
+    while cur <= end:
+        chunk_end = min(cur + step - 1, end)
+        chunks.append((cur, chunk_end))
+        cur = chunk_end + 1
+    return chunks
+
+
+def export_orbx_chunk(frame_start, frame_end, export_dir, base_name):
+    """Launch ORBX export for a frame chunk and return filepath."""
+    scene = bpy.context.scene
+    scene.frame_start = frame_start
+    scene.frame_end = frame_end
+
+    name = f"{base_name}_{frame_start:03d}-{frame_end:03d}.orbx"
+    filepath = os.path.join(export_dir, name)
+
+    bpy.ops.export.orbx(
+        'EXEC_DEFAULT',
+        filepath=filepath,
+        check_existing=False,
+        filename=name,
+        frame_start=frame_start,
+        frame_end=frame_end,
+        frame_subframe=0.0,
+        filter_glob="*.orbx",
+    )
+
+    return filepath
+
+
+def is_file_created(filepath):
+    """Return True when the file appears on disk."""
+    return os.path.exists(filepath)
+
+
+def make_orbx_export_manager(task_queue, export_dir, prefix, overwrite, poll_interval=3.0):
+    """Create a timer callback to sequentially export ORBX chunks."""
+    state = {'waiting_for': None, 'current_fp': None}
+
+    def manager():
+        if state['waiting_for'] is None:
+            while task_queue:
+                coll, frm, to = task_queue.pop(0)
+                solo_collection(bpy.context, coll)
+                base_name = f"{prefix}_{coll.name}"
+                filename = f"{base_name}_{frm:03d}-{to:03d}.orbx"
+                filepath = os.path.join(export_dir, filename)
+                if os.path.exists(filepath) and not overwrite:
+                    print(f"Skipping existing {filename}")
+                    continue
+                fp = export_orbx_chunk(frm, to, export_dir, base_name)
+                state['waiting_for'] = fp
+                state['current_fp'] = fp
+                return poll_interval
+
+            print("✅ All exports done.")
+            return None
+        else:
+            fp = state['waiting_for']
+            name = os.path.basename(fp)
+            if is_file_created(fp):
+                print(f"✔ Done {name}")
+                state['waiting_for'] = None
+                state['current_fp'] = None
+            else:
+                print(f"…waiting for {name}")
+            return poll_interval
+
+    return manager

--- a/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
@@ -1,0 +1,70 @@
+import os
+import bpy
+from bpy.types import Operator
+
+from ..properties import OctanePointCloudProperties
+from ..utils import (
+    ensure_directory,
+    build_scene_shot_prefix,
+)
+from ..Workflows.TAGs.utils import (
+    get_tagged_collections,
+    chunk_frame_ranges,
+    make_orbx_export_manager,
+)
+
+
+class LMB_OT_export_orbx_tags(Operator):
+    """Export tagged collections to ORBX files."""
+    bl_idname = "lmb.export_orbx_tags"
+    bl_label = "Export All Tags to ORBX"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        props = context.scene.otpc_props  # type: OctanePointCloudProperties
+        scene = context.scene
+
+        def resolve_scene_name():
+            if props.scene_name_source == 'FILE':
+                filepath = bpy.data.filepath
+                return os.path.splitext(os.path.basename(filepath))[0] if filepath else ""
+            if props.scene_name_source == 'SCENE':
+                return scene.name
+            return props.scene_name_manual
+
+        def resolve_shot_name():
+            if props.shot_name_source == 'OBJECT':
+                obj = props.shot_object_source
+                return obj.name if obj else ""
+            return props.shot_name_manual
+
+        collections = get_tagged_collections(scene)
+        if not collections:
+            self.report({'ERROR'}, "No tagged collections defined.")
+            return {'CANCELLED'}
+
+        scene_name = resolve_scene_name()
+        shot_name = resolve_shot_name()
+
+        base_root = bpy.path.abspath(props.root_output_dir)
+        prefix = build_scene_shot_prefix(scene_name, shot_name)
+        export_dir = os.path.join(base_root, "Shot_Manager", "TAGs", prefix)
+        ensure_directory(export_dir)
+
+        frame_start = props.tag_frame_start
+        frame_end = props.tag_frame_end
+        use_chunks = props.tag_use_chunks
+        chunk_size = max(1, props.tag_chunk_size)
+
+        ranges = chunk_frame_ranges(frame_start, frame_end, chunk_size) if use_chunks else [(frame_start, frame_end)]
+
+        task_queue = []
+        for coll in collections:
+            for frm, to in ranges:
+                task_queue.append((coll, frm, to))
+
+        export_manager = make_orbx_export_manager(task_queue, export_dir, prefix, props.overwrite_orbx, poll_interval=3.0)
+        bpy.app.timers.register(export_manager, first_interval=0.0)
+
+        self.report({'INFO'}, "ORBX export started.")
+        return {'FINISHED'}

--- a/LMI_OctaneShotManager_Blender/properties.py
+++ b/LMI_OctaneShotManager_Blender/properties.py
@@ -172,3 +172,9 @@ class OctanePointCloudProperties(bpy.types.PropertyGroup):
         default=25,
         min=1,
     )
+
+    overwrite_orbx: BoolProperty(
+        name="Overwrite ORBX",
+        description="Allow overwriting existing ORBX files",
+        default=False,
+    )

--- a/LMI_OctaneShotManager_Blender/registration.py
+++ b/LMI_OctaneShotManager_Blender/registration.py
@@ -4,6 +4,7 @@ from .icons import load_icons, unload_icons
 from .properties import OctanePointCloudProperties
 from .exporters.csv_export import LMB_OT_export_csv
 from .exporters.abc_export import LMB_OT_export_abc
+from .exporters.orbx_export import LMB_OT_export_orbx_tags
 from .Workflows.TAGs.tags_workflow import (
     TagCollectionItem,
     LMB_UL_tag_collections,
@@ -20,6 +21,7 @@ classes = (
     OctanePointCloudProperties,
     LMB_OT_export_csv,
     LMB_OT_export_abc,
+    LMB_OT_export_orbx_tags,
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,

--- a/LMI_OctaneShotManager_Blender/ui.py
+++ b/LMI_OctaneShotManager_Blender/ui.py
@@ -75,6 +75,8 @@ class POINTCLOUD_PT_panel(Panel):
             if p.tag_use_chunks:
                 row.prop(p, 'tag_chunk_size', text='Chunk')
             tag_box.operator('lmb.cycle_tag_collection', text='Cycle Collection')
+            tag_box.prop(p, 'overwrite_orbx')
+            tag_box.operator('lmb.export_orbx_tags', text='Export All Tags to ORBX', icon='EXPORT')
             layout.separator()
             
         # PointCloud Baker dropdown

--- a/Structure
+++ b/Structure
@@ -7,11 +7,13 @@ LMI_OctaneShotManager_Blender/
 ├── Workflows/                              # Contains different workflows logic
 │   └── TAGs/                               # Contains logic and helpers related to tagging workflows
         ├── ORBX_export_Example.py          # Example of ORBX export workflow
+        ├── utils.py                        # Helper functions for TAG workflow
 │       └── tags_workflow.py                # Logic for tagging workflow and related helpers
 ├── icons.py                                # Icon loading helpers
 ├── exporters/                              # Contains exporters logic
 │   ├── csv_export.py                       # CSV export operator & related helpers
-│   └── abc_export.py                       # Alembic export operator & face_sets logic
+│   ├── abc_export.py                       # Alembic export operator & face_sets logic
+│   └── orbx_export.py                      # Export ORBX files for tagged collections
 ├── standalone_scripts/                     # Contains standalone scripts for specific tasks
 │   └── ORBXmerger.lua                      # Tool for merging ORBX files
 ├── Icons/                                  # Contains icons used in the addon


### PR DESCRIPTION
## Summary
- create ORBX exporter for TAG workflow
- support chunked export processing
- expose overwrite option and export button in UI
- register new operator and property
- document new modules in Structure

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877cb0063d483209238bff7f8a0581d