### PR TITLE
Add part-aware ORBX export handling (variant 2)

### DIFF
--- a/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
+++ b/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
@@ -47,7 +47,7 @@ def cycle_tag_collections(context):
 
 
 def chunk_frame_ranges(start, end, step):
-    """Split [start..end] into sequential chunks of size 'step'."""
+    """Split ``start``..``end`` range into sequential chunks of ``step`` size."""
     chunks = []
     cur = start
     while cur <= end:
@@ -57,13 +57,72 @@ def chunk_frame_ranges(start, end, step):
     return chunks
 
 
-def export_orbx_chunk(frame_start, frame_end, export_dir, base_name):
+def calculate_part_ranges(start, end, chunk):
+    """Return ``(part_no, frm, to)`` tuples for the given frame range."""
+    parts = []
+    part_no = 1
+    for frm, to in chunk_frame_ranges(start, end, chunk):
+        parts.append((part_no, frm, to))
+        part_no += 1
+    return parts
+
+
+def parse_orbx_sequence(export_dir, base_name):
+    """Parse existing ORBX files and return part ranges and chunk sizes."""
+    import re
+
+    regex = re.compile(rf"^{re.escape(base_name)}_pt(\d+)_(\d+)-(\d+)\.orbx$")
+    parts = {}
+    sizes = set()
+    if not os.path.isdir(export_dir):
+        return parts, sizes
+    for fname in os.listdir(export_dir):
+        match = regex.match(fname)
+        if not match:
+            continue
+        part = int(match.group(1))
+        frm = int(match.group(2))
+        to = int(match.group(3))
+        parts[part] = (frm, to)
+        sizes.add(to - frm + 1)
+    return parts, sizes
+
+
+def filter_missing_parts(parts, export_dir, base_name, overwrite):
+    """Return only missing parts based on existing files in ``export_dir``."""
+    existing_parts, chunk_sizes = parse_orbx_sequence(export_dir, base_name)
+
+    if chunk_sizes and not overwrite:
+        requested_size = max(to - frm + 1 for _, frm, to in parts)
+        existing_size = max(chunk_sizes)
+        if existing_size != requested_size:
+            first_part_start = parts[0][1]
+            min_existing_start = min(frm for frm, _ in existing_parts.values())
+            sugg_start = (
+                (first_part_start - min_existing_start) // existing_size
+            ) * existing_size + min_existing_start
+            sugg_end = sugg_start + existing_size - 1
+            raise ValueError(
+                f"Existing sequence uses chunk size {existing_size}. "
+                f"Try exporting {sugg_start}-{sugg_end} instead."
+            )
+
+    missing = []
+    for part_no, frm, to in parts:
+        filename = f"{base_name}_pt{part_no}_{frm:03d}-{to:03d}.orbx"
+        filepath = os.path.join(export_dir, filename)
+        if overwrite or not os.path.exists(filepath):
+            missing.append((part_no, frm, to))
+    return missing
+
+
+def export_orbx_chunk(part_no, frame_start, frame_end, export_dir, base_name):
     """Launch ORBX export for a frame chunk and return filepath."""
     scene = bpy.context.scene
     scene.frame_start = frame_start
     scene.frame_end = frame_end
 
-    name = f"{base_name}_{frame_start:03d}-{frame_end:03d}.orbx"
+    name = f"{base_name}_pt{part_no}_{frame_start:03d}-{frame_end:03d}.orbx"
     filepath = os.path.join(export_dir, name)
 
     bpy.ops.export.orbx(
@@ -92,15 +151,15 @@ def make_orbx_export_manager(task_queue, export_dir, prefix, overwrite, poll_int
     def manager():
         if state['waiting_for'] is None:
             while task_queue:
-                coll, frm, to = task_queue.pop(0)
+                coll, part_no, frm, to = task_queue.pop(0)
                 solo_collection(bpy.context, coll)
                 base_name = f"{prefix}_{coll.name}"
-                filename = f"{base_name}_{frm:03d}-{to:03d}.orbx"
+                filename = f"{base_name}_pt{part_no}_{frm:03d}-{to:03d}.orbx"
                 filepath = os.path.join(export_dir, filename)
                 if os.path.exists(filepath) and not overwrite:
                     print(f"Skipping existing {filename}")
                     continue
-                fp = export_orbx_chunk(frm, to, export_dir, base_name)
+                fp = export_orbx_chunk(part_no, frm, to, export_dir, base_name)
                 state['waiting_for'] = fp
                 state['current_fp'] = fp
                 return poll_interval

--- a/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
@@ -9,7 +9,8 @@ from ..utils import (
 )
 from ..Workflows.TAGs.utils import (
     get_tagged_collections,
-    chunk_frame_ranges,
+    calculate_part_ranges,
+    filter_missing_parts,
     make_orbx_export_manager,
 )
 
@@ -56,12 +57,25 @@ class LMB_OT_export_orbx_tags(Operator):
         use_chunks = props.tag_use_chunks
         chunk_size = max(1, props.tag_chunk_size)
 
-        ranges = chunk_frame_ranges(frame_start, frame_end, chunk_size) if use_chunks else [(frame_start, frame_end)]
+        part_ranges = calculate_part_ranges(
+            frame_start,
+            frame_end,
+            chunk_size if use_chunks else frame_end - frame_start + 1,
+        )
 
         task_queue = []
         for coll in collections:
-            for frm, to in ranges:
-                task_queue.append((coll, frm, to))
+            base_name = f"{prefix}_{coll.name}"
+            try:
+                parts = filter_missing_parts(
+                    part_ranges, export_dir, base_name, props.overwrite_orbx
+                )
+            except ValueError as exc:
+                self.report({'ERROR'}, str(exc))
+                return {'CANCELLED'}
+
+            for part_no, frm, to in parts:
+                task_queue.append((coll, part_no, frm, to))
 
         export_manager = make_orbx_export_manager(task_queue, export_dir, prefix, props.overwrite_orbx, poll_interval=3.0)
         bpy.app.timers.register(export_manager, first_interval=0.0)


### PR DESCRIPTION
## Summary
- implement helper to calculate part ranges
- detect existing ORBX chunks and skip or error on mismatched chunk sizes
- export ORBX chunks using part numbers in filenames
- update ORBX exporter to use new part logic

## Testing
- `python -m py_compile LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py LMI_OctaneShotManager_Blender/exporters/orbx_export.py`

------
https://chatgpt.com/codex/tasks/task_e_68781bcd2fc48320bfe129927467d46f