### PR TITLE
Add compound ORBX export option

### DIFF
--- a/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
+++ b/LMI_OctaneShotManager_Blender/Workflows/TAGs/utils.py
@@ -279,7 +279,7 @@ def make_orbx_export_manager(task_queue, export_dir, prefix, overwrite, poll_int
     return manager
 
 
-def make_compound_orbx_export_manager(task_queue, export_dir, base_name, overwrite, poll_interval=3.0):
+def make_all_in_one_orbx_export_manager(task_queue, export_dir, base_name, overwrite, poll_interval=3.0):
     """Create a timer callback to export ORBX chunks without soloing."""
     state = {'waiting_for': None}
 

--- a/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_export.py
@@ -12,7 +12,7 @@ from ..Workflows.TAGs.utils import (
     calculate_part_ranges,
     filter_missing_parts,
     make_orbx_export_manager,
-    make_compound_orbx_export_manager,
+    make_all_in_one_orbx_export_manager,
 )
 
 
@@ -88,10 +88,10 @@ class LMB_OT_export_orbx_tags(Operator):
         return {'FINISHED'}
 
 
-class LMB_OT_export_orbx_compound(Operator):
+class LMB_OT_export_orbx_all_in_one(Operator):
     """Export all tagged collections to a single ORBX sequence."""
-    bl_idname = "lmb.export_orbx_compound"
-    bl_label = "Export all Tags as a Compound ORBX"
+    bl_idname = "lmb.export_orbx_all_in_one"
+    bl_label = "Export all Tags to an 'All-in-one' ORBX"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -118,7 +118,7 @@ class LMB_OT_export_orbx_compound(Operator):
 
         ranges = calculate_part_ranges(frame_start, frame_end, chunk_size) if use_chunks else [(1, frame_start, frame_end)]
 
-        base_name = f"{prefix}_Compound"
+        base_name = f"{prefix}_AllInOne"
         try:
             parts = filter_missing_parts(
                 ranges,
@@ -133,7 +133,7 @@ class LMB_OT_export_orbx_compound(Operator):
 
         task_queue = [(part_no, frm, to) for part_no, frm, to in parts]
 
-        export_manager = make_compound_orbx_export_manager(task_queue, export_dir, base_name, props.overwrite_orbx, poll_interval=3.0)
+        export_manager = make_all_in_one_orbx_export_manager(task_queue, export_dir, base_name, props.overwrite_orbx, poll_interval=3.0)
         bpy.app.timers.register(export_manager, first_interval=0.0)
 
         self.report({'INFO'}, "ORBX export started.")

--- a/LMI_OctaneShotManager_Blender/registration.py
+++ b/LMI_OctaneShotManager_Blender/registration.py
@@ -4,7 +4,7 @@ from .icons import load_icons, unload_icons
 from .properties import OctanePointCloudProperties
 from .exporters.csv_export import LMB_OT_export_csv
 from .exporters.abc_export import LMB_OT_export_abc
-from .exporters.orbx_export import LMB_OT_export_orbx_tags, LMB_OT_export_orbx_compound
+from .exporters.orbx_export import LMB_OT_export_orbx_tags, LMB_OT_export_orbx_all_in_one
 from .Workflows.TAGs.tags_workflow import (
     TagCollectionItem,
     LMB_UL_tag_collections,
@@ -22,7 +22,7 @@ classes = (
     LMB_OT_export_csv,
     LMB_OT_export_abc,
     LMB_OT_export_orbx_tags,
-    LMB_OT_export_orbx_compound,
+    LMB_OT_export_orbx_all_in_one,
     LMB_UL_tag_collections,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,

--- a/LMI_OctaneShotManager_Blender/ui.py
+++ b/LMI_OctaneShotManager_Blender/ui.py
@@ -77,7 +77,7 @@ class POINTCLOUD_PT_panel(Panel):
             tag_box.operator('lmb.cycle_tag_collection', text='Cycle Collection')
             tag_box.prop(p, 'overwrite_orbx')
             tag_box.operator('lmb.export_orbx_tags', text="Export all Tags to a 'Per Tag' ORBX", icon='EXPORT')
-            tag_box.operator('lmb.export_orbx_compound', text='Export all Tags as a Compound ORBX', icon='EXPORT')
+            tag_box.operator('lmb.export_orbx_all_in_one', text="Export all Tags to an 'All-in-one' ORBX", icon='EXPORT')
             layout.separator()
             
         # PointCloud Baker dropdown


### PR DESCRIPTION
## Summary
- rename tag exporter label
- implement compound ORBX exporter
- expose new exporter via UI and registration
- add helper function for compound exports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687840d7362883208f2b99ea89f0da34